### PR TITLE
Subsites 3 support (for SS5)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=7.1",
         "firesphere/solr-search": ">=1.0",
-        "silverstripe/subsites": "^2"
+        "silverstripe/subsites": "^2 | ^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
When using subsites with Silverstripe 5.2, the module won't install because of this incompatible dependency